### PR TITLE
checking if spriteAnimation frames count is 0 on Play

### DIFF
--- a/Runtime/SpriteAnimator.cs
+++ b/Runtime/SpriteAnimator.cs
@@ -63,7 +63,7 @@ namespace GabrielBigardi.SpriteAnimator
 
         public SpriteAnimator Play(SpriteAnimation spriteAnimation, int startFrame = 0)
         {
-            if (spriteAnimation == null)
+            if (spriteAnimation == null || spriteAnimation.Frames.Count <= 0)
             {
                 Debug.LogError("An null or invalid SpriteAnimation object was passed.");
                 return null;


### PR DESCRIPTION
Still gets an error when the animation has zero frames, but the error was the one setted on the Play function.