### PR TITLE
Fixed web build conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Rider cache directory
+.idea/

--- a/Editor/ExtendedEditorWindow.cs
+++ b/Editor/ExtendedEditorWindow.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -142,3 +143,4 @@ namespace GabrielBigardi.SpriteAnimator
         protected virtual void OnElementClicked() { }
     }
 }
+#endif

--- a/Editor/SpriteAnimationCustomEditor.cs
+++ b/Editor/SpriteAnimationCustomEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
@@ -30,5 +31,5 @@ namespace GabrielBigardi.SpriteAnimator
             }
         }
     }
-
 }
+#endif

--- a/Editor/SpriteAnimationEditorWindow.cs
+++ b/Editor/SpriteAnimationEditorWindow.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Collections;
 using System.IO;
 using System.Linq;
@@ -231,3 +232,4 @@ namespace GabrielBigardi.SpriteAnimator
         }
     }
 }
+#endif


### PR DESCRIPTION
I tried to build for the web, but the build failed due to several errors. The conflicts were in the files: `ExtendedEditorWindow`, `SpriteAnimationCustomEditor`, and `SpriteAnimationEditorWindow`. These files are only needed in UnityEditor, so I added `#if UNITY_EDITOR` at the beginning and `#endif` at the end of the files. Now, I can build for the web without any errors. Additionally, I added the Rider cache directory to the `.gitignore` file.