### PR TITLE
Fix SpriteAnimationEditorWindow when previewing packed sprites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-09-30
+### Fixed
+- SpriteAnimationEditorWindow when previewing packed sprites.
+
 ## [2.0.3] - 2023-07-04
 ### Added
 - Readded assembly definition for package importing with .git url

--- a/Editor/SpriteAnimationEditorWindow.cs
+++ b/Editor/SpriteAnimationEditorWindow.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.Sprites;
 using UnityEngine;
 
 namespace GabrielBigardi.SpriteAnimator
@@ -341,9 +342,9 @@ namespace GabrielBigardi.SpriteAnimator
 
         public void GUIDrawSprite(Rect previewRect, Sprite sprite)
         {
-            // Get the sprite's rect and texture
+            // Get the sprite's original rect and texture
             Rect spriteRect = sprite.rect;
-            Texture2D texture = sprite.texture;
+            Texture2D texture = SpriteUtility.GetSpriteTexture(sprite, false);
 
             // Calculate the aspect ratio of the sprite
             float spriteAspectRatio = spriteRect.width / spriteRect.height;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.gabrielbigardi.spriteanimator",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "displayName": "2D Sprite Animator",
   "description": "Performatic, simple and easy animator for 2D games",
   "unity": "6000.0",


### PR DESCRIPTION
Always uses the `Sprite`'s original `Texture` when previewed in the Editor Window.

Fixes #10 